### PR TITLE
Update Database.php

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -193,29 +193,28 @@ class Database
      */
     public function update($table, $data, $where)
     {
-        //merge data and where together
-        $collection = array_merge($data, $where);
-
-        //collect the values from collection
-        $values = array_values($collection);
-
+        //collect the values from data and where
+        $values = [];
+        
         //setup fields
         $fieldDetails = null;
         foreach ($data as $key => $value) {
             $fieldDetails .= "$key = ?,";
+            $values[] = $value;
         }
         $fieldDetails = rtrim($fieldDetails, ',');
-
+        
         //setup where 
         $whereDetails = null;
         $i = 0;
         foreach ($where as $key => $value) {
             $whereDetails .= $i == 0 ? "$key = ?" : " AND $key = ?";
+            $values[] = $value;
             $i++;
         }
-
+        
         $stmt = $this->run("UPDATE $table SET $fieldDetails WHERE $whereDetails", $values);
-
+        
         return $stmt->rowCount();
     }
 

--- a/src/Database.php
+++ b/src/Database.php
@@ -76,8 +76,25 @@ class Database
         }
 
         $stmt = $this->db->prepare($sql);
-        $stmt->execute($args);
-
+        
+        //check if args is associative or sequential?
+        $is_assoc = (array() === $args) ? false : array_keys($args) !== range(0, count($args) - 1);
+        if ($is_assoc)
+        {
+            foreach ($args as $key => $value) {
+                if (is_int($value)) {
+                    $stmt->bindValue(":$key", $value, PDO::PARAM_INT);
+                } else {
+                    $stmt->bindValue(":$key", $value);
+                }
+            }
+            $stmt->execute();
+        }
+        else
+        {
+            $stmt->execute($args);
+        }
+        
         return $stmt;
     }
 


### PR DESCRIPTION
**Fix ORDER & LIMIT argument type casting.**
Bind integers as 'PARAM_INT' when running query - prevent explicit int values (such as in ORDER or LIMIT) from being quoted.

**Fix 'update' where $data and $where fields have the same column**
Merge array of $data and $where in update will result in omitted data if $data and $where fields have the same columns.  Updated to append all passed values, so same columns in $data and $where will now use both values.